### PR TITLE
Fix cmake flag typo

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -130,7 +130,7 @@ Alternatively, you can use **CLion**. If you chose to do so, open the directory 
 At the moment we only support **x86_64** builds. It is possible to build using AppleSilicon hardware but **mad** and **id3tag** should be disabled:
 
 ```
-cmake -GXCode -T buildsystem=1 -Dsaucedacity_use_mad="off" -Dsaucedacity_use_id3tag=off ../saucedacity
+cmake -G Xcode -T buildsystem=1 -Dsaucedacity_use_mad="off" -Dsaucedacity_use_id3tag=off ../saucedacity
 ```
 
 ## Linux & Other OS


### PR DESCRIPTION
Resolves: N/A

There was a typo in this command.

<!-- Use "x" to fill the checkboxes below like [x] -->

- **N/A** I made sure the code compiles on my machine **N/A**
- **N/A** I made sure there are no unnecessary changes in the code
- **N/A** I made sure the title of the PR reflects the core meaning of the issue you are solving
- **N/A** I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"

*(an optional longer description of the changes)*
