### PR TITLE
IPC refactoring part 1

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1088,6 +1088,7 @@ list( APPEND LIBRARIES
       $<$<PLATFORM_ID:Linux,FreeBSD,OpenBSD,NetBSD,CYGWIN>:PkgConfig::GTK>
       $<$<PLATFORM_ID:Linux,FreeBSD,OpenBSD,NetBSD,CYGWIN>:z>
       $<$<PLATFORM_ID:Linux,FreeBSD,OpenBSD,NetBSD,CYGWIN>:pthread>
+      $<$<PLATFORM_ID:Linux,FreeBSD,OpenBSD,NetBSD,CYGWIN>:rt>
 )
 
 set( BUILDING_AUDACITY YES )

--- a/src/SaucedacityApp.cpp
+++ b/src/SaucedacityApp.cpp
@@ -1770,6 +1770,15 @@ bool SaucedacityApp::CreateSingleInstanceChecker(const wxString& /* unused */)
    }
 #endif
 
+   // Let the user know that another copy is running.
+   AudacityMessageBox(XO("Another copy of Saucedacity has been detected"
+                           "running on this system. Running multiple copies of"
+                           "Saucedacity is not supported\n\n"
+                           "You will now be redirected to the running copy."),
+                      XO("Saucedacity is already running"),
+                      wxOK
+   );
+
    // On macOS and Linux, forward any file names found in the command
    // line arguments.
    for (size_t j = 0, cnt = parser->GetParamCount(); j < cnt; ++j)

--- a/src/SaucedacityApp.cpp
+++ b/src/SaucedacityApp.cpp
@@ -717,6 +717,11 @@ void SaucedacityApp::OnTimer(wxTimerEvent& WXUNUSED(event))
 
 void SaucedacityApp::OnFatalException()
 {
+   #ifdef __UNIX__
+      // Cleanup our IPC resources. Error checking isn't that important given
+      // we're crashing already.
+      CleanupIPCResources();
+   #endif
    exit(-1);
 }
 

--- a/src/SaucedacityApp.cpp
+++ b/src/SaucedacityApp.cpp
@@ -1615,13 +1615,6 @@ bool SaucedacityApp::CreateSingleInstanceChecker(const wxString& /* unused */)
       // Lock both the server and lock semaphores. The server isn't ready yet.
       if (sem_wait(mServerSemaphore) !=0)
       {
-         // Note: any error should not be EAGAIN because the semaphore did not
-         // exist previously and the semaphore was already set in a released
-         // state. Therefore, if there's any error, it should not be EAGAIN.
-         //
-         // This is more or less for debugging purposes.
-         wxASSERT(errno != EAGAIN);
-
          AudacityMessageBox(
             XO("Unable to acquire semaphores.\n\n"
                "This is likely due to a resource shortage\n"

--- a/src/SaucedacityApp.h
+++ b/src/SaucedacityApp.h
@@ -116,16 +116,19 @@ class SaucedacityApp final : public wxApp {
    std::unique_ptr<wxSocketServer> mIPCServ;
 
    sem_t* mLockSemaphore;
-   static constexpr const char* LockSemName = "/SaucedacityLock";
+
+   static constexpr const char* LockSemName   = "/SaucedacityLock";
+   static constexpr const char* SharedMemName = "/SaucedacityMem";
    bool mWasServer;
 
-   /** @brief Cleans up ALL semaphores created by any "server" processes.
+   /** @brief Cleans up ALL IPC resources created by any "server" processes.
     *
-    * It is GUARANTEED that all semaphores are cleaned up and removed from the
-    * system at exit, unless something catastrophic happens.
+    * It is GUARANTEED that ALL RESOURCES created by the "server" process are
+    * cleaned up and removed from the system at exit, unless something
+    * catastrophic happens.
     *
     **/
-   void CleanupSemaphores();
+   void CleanupIPCResources();
 #endif
 
  public:

--- a/src/SaucedacityApp.h
+++ b/src/SaucedacityApp.h
@@ -23,6 +23,10 @@
 
 #include <memory>
 
+#ifdef __UNIX__
+#include <semaphore.h>
+#endif
+
 class wxSingleInstanceChecker;
 class wxSocketEvent;
 class wxSocketServer;
@@ -110,6 +114,10 @@ class SaucedacityApp final : public wxApp {
    std::unique_ptr<IPCServ> mIPCServ;
 #else
    std::unique_ptr<wxSocketServer> mIPCServ;
+
+   sem_t* mServerSemaphore;
+   static constexpr const char* LockSemName = "/SaucedacityLock";
+   bool mWasServer;
 #endif
 
  public:

--- a/src/SaucedacityApp.h
+++ b/src/SaucedacityApp.h
@@ -115,9 +115,17 @@ class SaucedacityApp final : public wxApp {
 #else
    std::unique_ptr<wxSocketServer> mIPCServ;
 
-   sem_t* mServerSemaphore;
+   sem_t* mLockSemaphore;
    static constexpr const char* LockSemName = "/SaucedacityLock";
    bool mWasServer;
+
+   /** @brief Cleans up ALL semaphores created by any "server" processes.
+    *
+    * It is GUARANTEED that all semaphores are cleaned up and removed from the
+    * system at exit, unless something catastrophic happens.
+    *
+    **/
+   void CleanupSemaphores();
 #endif
 
  public:


### PR DESCRIPTION
This is intended to prepare Saucedacity for an entire IPC rewrite using Boost.Interprocess and Boost.ASIO. Part 1 of the IPC rewrite is already implemented for UNIX platforms (i.e., macOS, FreeBSD, Linux, etc). Part 2 involves the full rewrite of the Windows implementation (using the same methods as on UNIX platforms) **and** the actual IPC server itself. In this PR, the IPC server itself has been untouched.

- [x] I made sure the code compiles on my machine*
- [x] I made sure that my contributes are licensed under GPL v2 or later.*
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"

\*Indicates required.
